### PR TITLE
Bug and Fix: Memory Leakage

### DIFF
--- a/extract_features.py
+++ b/extract_features.py
@@ -116,7 +116,7 @@ def extract_feat(split_idx, img_list, cfg, args, actor: ActorHandle):
                 attr_scores = [attr_score.cpu() for attr_score in attr_scores]
             generate_npz(1, 
                 args, cfg, im_file, im, dataset_dict, 
-                boxes, scores, features_pooled, attr_scores))
+                boxes, scores, features_pooled, attr_scores)
         # extract bbox only
         elif cfg.MODEL.BUA.EXTRACTOR.MODE == 2:
             with torch.set_grad_enabled(False):
@@ -125,7 +125,7 @@ def extract_feat(split_idx, img_list, cfg, args, actor: ActorHandle):
             scores = [score.cpu() for score in scores]
             generate_npz(2,
                 args, cfg, im_file, im, dataset_dict, 
-                boxes, scores))
+                boxes, scores)
         # extract roi features by bbox
         elif cfg.MODEL.BUA.EXTRACTOR.MODE == 3:
             if not os.path.exists(os.path.join(args.bbox_dir, im_file.split('.')[0]+'.npz')):
@@ -149,7 +149,7 @@ def extract_feat(split_idx, img_list, cfg, args, actor: ActorHandle):
                 attr_scores = [attr_score.data.cpu() for attr_score in attr_scores]
             generate_npz(3, 
                 args, cfg, im_file, im, dataset_dict, 
-                boxes, scores, features_pooled, attr_scores))
+                boxes, scores, features_pooled, attr_scores)
 
         actor.update.remote(1)
 


### PR DESCRIPTION
**Bug Details:**
I try to extract the RoI features in my own dataset (a big dataset including more than 50k+ pictures), the `extract_features.py` will continually allocate the memory without releasing and finally exceed the memory limitation. The main reason is due to the ray memory management mechanism which will hold the memory until the task nodes are deleted. So the [way](https://github.com/MILVLG/bottom-up-attention.pytorch/blob/c9ffcedc8fdb23ede994e86a4f6c89f7688f8a9a/extract_features.py#L157) we generate `npz` file is infeasible, which will cause memory leakage.

**Solution**
I reorganize the save mechanism without hurting the speed performance which can reach *6.48it/s* on average, also be faster than before, while the memory usage is controllable.
